### PR TITLE
add web3 shim

### DIFF
--- a/src/frame.js
+++ b/src/frame.js
@@ -5,9 +5,7 @@ function shimWeb3(provider) {
   let loggedCurrentProvider = false
 
   if (!window.web3) {
-    let web3Shim = { currentProvider: provider }
-
-    web3Shim = new Proxy(web3Shim, {
+    const web3Shim = new Proxy({ currentProvider: provider }, {
       get: (target, property, ...args) => {
         if (property === 'currentProvider' && !loggedCurrentProvider) {
           loggedCurrentProvider = true


### PR DESCRIPTION
Legacy web3 apps use the `window.web3` object to access the provider, we can add a shim to enable these to still work in some capacity.