### PR TITLE
update chains on connect when wallet_getEthereumChains is unsupported

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ function setCurrentChain (chain) {
 provider.on('connect', () => {
   frameState.connected = true
   if (settingsPanel) settingsPanel.postMessage(frameState)
-  provider.request({ method: 'wallet_getEthereumChains' }).then(setChains).catch(() => {})
+  provider.request({ method: 'wallet_getEthereumChains' }).then(setChains).catch(() => setChains([]))
 
   sendEvent('connect')
 })


### PR DESCRIPTION
Enabling a smoother experience when switching between canary and prod Frame