### PR TITLE
fix return type of _metamask.isUnlocked method in metamask provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frame-extension",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "frame-extension",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "dependencies": {
         "@babel/preset-env": "7.18.2",
         "@babel/runtime": "7.18.3",

--- a/src/frame.js
+++ b/src/frame.js
@@ -101,9 +101,7 @@ if (mmAppear) {
     provider = new MetaMaskProvider(new Connection())
     provider.isMetaMask = true
     provider._metamask = {
-      isUnlocked: () => new Promise((resolve) => {
-        resolve(true)
-      })
+      isUnlocked: () => new Promise((resolve) => resolve(true))
     }
     provider.setMaxListeners(0)
   } catch (e) {

--- a/src/frame.js
+++ b/src/frame.js
@@ -101,7 +101,9 @@ if (mmAppear) {
     provider = new MetaMaskProvider(new Connection())
     provider.isMetaMask = true
     provider._metamask = {
-      isUnlocked: () => true
+      isUnlocked: () => new Promise((resolve) => {
+        resolve(true)
+      })
     }
     provider.setMaxListeners(0)
   } catch (e) {


### PR DESCRIPTION
`_metamask.isUnlocked` method returns `boolean` instead of `Promise<boolean>` (as defined in metamask ethereum provider api [docs](https://docs.metamask.io/guide/ethereum-provider.html#ethereum-metamask-isunlocked)), which causes wallet connection to fail in apps like [app.level.finance](https://app.level.finance/).

This PR fixes this issue and updates package lock version.