### PR TITLE
Replace provider on active

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -29,7 +29,7 @@
       "all_frames": true
     }
   ],
-  "permissions": ["activeTab", "https://*/*", "http://*/*", "tabs"],
+  "permissions": ["activeTab", "https://*/*", "http://*/*", "tabs", "idle"],
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",


### PR DESCRIPTION
Replacing the provider when the `idle` API state changes to 'active'. 