### PR TITLE
Fix tab error

### DIFF
--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -481,7 +481,7 @@ class _Settings extends React.Component {
 
     return rows.map((row) => (
       <ClusterRow style={{ justifyContent: 'flex-start' }}>
-        {row.map((chain, i) => <ChainButton index={i} chain={chain} tab={this.tab} selected={chain.chainId === parseInt(currentChain, 16)} />)}
+        {row.map((chain, i) => <ChainButton index={i} chain={chain} tab={this.props.tab} selected={chain.chainId === parseInt(currentChain, 16)} />)}
       </ClusterRow>
     ))
   }


### PR DESCRIPTION
The recent changes in #38 passed an undefined tab prop into the new ChainButton component which broke the chain switching, this PR is to rectify that.